### PR TITLE
Individual test links not resolving

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -144,7 +144,7 @@ public class SlackClient {
 			final String featureFileName = feature.getKey();
 			String featureName = featureFileName.replace(".feature", "");
 			featureName = featureName.replaceAll("_", " ");
-			fields.add(shortObject("<" + hyperLink + featureFileName + ".html|" + featureName + ">"));
+			fields.add(shortObject("<" + hyperLink + featureFileName.replaceAll("\\.", "-") + ".html|" + featureName + ">"));
 			fields.add(shortObject(feature.getValue() + " %"));
 		}
 		fields.add(shortObject("-------------------------------"));


### PR DESCRIPTION
The featureFileName contains the '.feature' type, the '.' needs to be substituted with a hyphen ('-') within the hyperlink to resolve correctly.
